### PR TITLE
INT-7896 - Additional warn info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 1.0.0-beta.4 2023-05-31
+
+## Changed
+
+- Added additional logging for warnings when the 10,000 entries limit is
+  reached.
+
 ## 1.0.0-beta.3 2023-05-30
 
 ## Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-sonarqube",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.4",
   "description": "Sonarqube integration for JupiterOne",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/provider/SonarqubeClient.ts
+++ b/src/provider/SonarqubeClient.ts
@@ -164,12 +164,14 @@ export class SonarqubeClient {
       if (page * ITEMS_PER_PAGE > 10000) {
         // We have a hard limit of 10,000 items imposed by the current API
         this.logger.warn(
-          { page, endpoint },
+          { page, endpoint, params },
           `Unable to paginate through more than 10,000 total entries due to API limitations.  Not all data will be ingested.`,
         );
         this.logger.publishWarnEvent({
           name: IntegrationWarnEventName.IngestionLimitEncountered,
-          description: `Unable to paginate through more than 10,000 total entries due to API limitations.  Not all data will be ingested.`,
+          description: `Unable to paginate through more than 10,000 total entries due to API limitations.  Not all data will be ingested.  Endpoint: [${endpoint}]   Parameters: [${JSON.stringify(
+            params,
+          )}]`,
         });
         break;
       }


### PR DESCRIPTION
Adding additional information to the warning message to allow customers to see what project/severity failed to ingest beyond the 10,000 limit.